### PR TITLE
Removed all old Ipython notebook headers. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Data Carpentry with NLTK and IPython
 
-<img style="float:left" src="http://ipython.org/_static/IPy_header.png" />
-<br>
-
 This repository contains teaching materials for Saarland Uni's *Working With Corpora* program. It's been adapted from the repository for teaching materials and additional resources used by Research Platforms Services to teach *Python*, *IPython* and the *Natural Language Toolkit* (*NLTK*).
 
 All the materials used in the workshops are in this repository. In fact, cloning this repository will be our first activity together as a group. To do that, just open your terminal and type/paste:

--- a/resources/completed-notebooks/nltk-session-1-complete.md
+++ b/resources/completed-notebooks/nltk-session-1-complete.md
@@ -1,7 +1,3 @@
-<br>
-<img style="float:left" src="http://ipython.org/_static/IPy_header.png" />
-<br>
-
 # Session 1: Orientation
 
 <br>

--- a/resources/completed-notebooks/nltk-session-2-complete.md
+++ b/resources/completed-notebooks/nltk-session-2-complete.md
@@ -1,7 +1,3 @@
-<br>
-<img style="float:left" src="http://ipython.org/_static/IPy_header.png" />
-<br>
-
 # Session 2: Common NLTK tasks
 
 <br>

--- a/resources/completed-notebooks/nltk-session-3-complete.md
+++ b/resources/completed-notebooks/nltk-session-3-complete.md
@@ -1,7 +1,3 @@
-<br>
-<img style="float:left" src="http://ipython.org/_static/IPy_header.png" />
-<br>
-
 # Session 3: Charting change in Fraser's speeches
 
 In this lesson, we investigate a fully-parsed version of the Fraser Corpus. We

--- a/resources/completed-notebooks/nltk-session-4-complete.md
+++ b/resources/completed-notebooks/nltk-session-4-complete.md
@@ -1,6 +1,3 @@
-<br>
-<img style="float:left" src="http://ipython.org/_static/IPy_header.png" />
-<br>
 
 # Session 4: Getting the most out of what we've learned
 


### PR DESCRIPTION
I think it's kind of clunky to have the header on top of the notebook especially when presenting. In anyways, if we were to use the ipython headers, we should be using the new jupyter headers =)